### PR TITLE
Remove unused derived instances

### DIFF
--- a/Haskell/src/UserManagement.hs
+++ b/Haskell/src/UserManagement.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE LambdaCase #-}
 module UserManagement where
 
@@ -7,7 +6,7 @@ import Data.Either
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except
 
-data HttpResponse a = OK a | BadRequest String deriving (Show, Eq, Functor)
+data HttpResponse a = OK a | BadRequest String
 
 isOK :: HttpResponse a -> Bool
 isOK (OK _) = True
@@ -22,7 +21,7 @@ data User = User { userId :: Integer, connectedUsers :: [User] } deriving (Show,
 addConnection :: User -> User -> User
 addConnection (User i cns) otherUser = User i $ otherUser : cns
 
-data UserLookupError = InvalidId | NotFound deriving (Show, Eq)
+data UserLookupError = InvalidId | NotFound
 
 post :: Monad m =>
         (a -> m (Either UserLookupError User)) ->


### PR DESCRIPTION
Makes the code easier to read on a plain text editor (GitHub, Sublime Text with no add-ins, etcetera). It passes all automated tests.

---

```
$ stack test
UserManagement-0.1.0.0: test (suite: UserManagement-test)

Properties:
  Users successfully connect: [OK, passed 100 tests]
  Users don't connect when user doesn't exist: [OK, passed 100 tests]
  Users don't connect when other user doesn't exist: [OK, passed 100 tests]
  Users don't connect when user Id is invalid: [OK, passed 100 tests]
  Users don't connect when other user Id is invalid: [OK, passed 100 tests]

         Properties  Total
 Passed  5           5
 Failed  0           0
 Total   5           5

UserManagement-0.1.0.0: Test suite UserManagement-test passed

Nikos@WIN-NJGAFM9CA3G MINGW64 ~/tmp/ploeh/UserManagement/Haskell
  (topic/housekeeping-haskell-derived-instances)
```
